### PR TITLE
feat: update extraction prompt (remove Macro, add D/C, add page conte…

### DIFF
--- a/app/gemini_extractor.py
+++ b/app/gemini_extractor.py
@@ -16,67 +16,49 @@ logger = logging.getLogger(__name__)
 EXTRACTION_PROMPT = """\
 Extraia TODAS as linhas do balancete contábil desta página.
 Retorne um JSON no formato:
-{
+{{
   "periodo": "09/2023",
   "type": "BP",
   "ano_atual": "2024",
   "ano_anterior": "2023",
   "rows": [
-    {
+    {{
       "Conta": "Caixa e Equivalentes",
       "Mascara_Contabil": "1.01.01",
       "Ano_Anterior": 1234.56,
-      "Ano_Atual": 5678.90,
-      "Macro": false
-    }
+      "Ano_Atual": 5678.90
+    }}
   ]
-}
+}}
 
 REGRAS:
 
-1. PERIODO:
-   - Identifique o período de referência no cabeçalho do documento.
-   - Formatos aceitos: "MM/YYYY" (mensal), "YYYY" (anual), "MM/YYYY a MM/YYYY" (intervalo).
-   - Se não encontrar, use "".
+1. PERIODO: Identifique o período de referência no cabeçalho. Formato "MM/YYYY" ou "YYYY". Se não encontrar, use "".
 
-2. TYPE — use APENAS estes valores:
+2. TYPE — APENAS dois valores:
    - "DRE" se o conteúdo for Demonstração do Resultado (palavras-chave: Receita, Despesa, Custo, Resultado Operacional, Lucro, Prejuízo).
    - "BP" para todo o resto (Balanço Patrimonial, Balancete, Ativo, Passivo, Patrimônio Líquido).
 
-3. ANOS:
-   - "ano_atual" e "ano_anterior" são os anos exibidos nas colunas (ex: "2024", "2023").
-   - Se não houver ano anterior, use "".
+3. ANOS: "ano_atual" e "ano_anterior" são os rótulos das colunas de valores (ex: "2024", "2023"). Se só houver uma coluna, "ano_anterior" = "".
 
 4. VALORES MONETÁRIOS — CRÍTICO:
-   - Retorne números decimais usando PONTO como separador decimal.
-   - Remova R$, pontos de milhar, e converta vírgula decimal para ponto.
-   - Exemplos:
-     R$ 1.234,56  → 1234.56
-     R$ 10.500,00 → 10500.00
-     415.883,97   → 415883.97
-     (1.234,56)   → -1234.56
-     0,00         → 0
-   - NÃO remova os centavos. 1.234,56 NÃO é 123456.
+   - Retorne decimais com PONTO como separador. Remova R$, pontos de milhar. Vírgula decimal vira ponto.
+   - Exemplos: R$ 1.234,56 → 1234.56 | (1.234,56) → -1234.56 | 0,00 → 0
+   - NÃO remova centavos. 1.234,56 NÃO é 123456.
+   - DÉBITO e CRÉDITO: Se a tabela tiver indicadores D/C:
+     • No Ativo e Despesas: D = valor positivo, C = valor negativo.
+     • No Passivo e Receitas: C = valor positivo, D = valor negativo.
+   - Se não houver D/C, mantenha o sinal numérico original (parênteses = negativo).
 
-5. CONTA — extraia APENAS o nome descritivo:
-   - Remova códigos numéricos e máscaras contábeis do início.
-   - Exemplos:
-     Errado: "1002518 1.01.02.001 CLAUDIO ROSSI" → Certo: "CLAUDIO ROSSI"
-     Errado: "310749 1.01.02.001 Companhia Uci"  → Certo: "Companhia Uci"
-     Correto: "Caixa e Equivalentes de Caixa"
+5. CONTA: Extraia APENAS o nome descritivo. Remova códigos numéricos e máscaras do início.
 
-6. MASCARA_CONTABIL:
-   - Extraia o código hierárquico (ex: "1", "1.01", "1.01.01", "1.01.01.001").
-   - Se não houver máscara visível, use "".
+6. MASCARA_CONTABIL: Extraia o código hierárquico (ex: "1", "1.01", "1.01.01"). Se não houver, use "".
 
-7. MACRO:
-   - true se a linha for título de grupo, subtotal ou total.
-   - false para contas analíticas (folha/detalhe).
+7. Extraia TODAS as linhas visíveis, sem omitir nenhuma. Se não houver valor, use 0.
 
-8. GERAL:
-   - Extraia TODAS as linhas visíveis, sem omitir nenhuma.
-   - Se não houver valor, use 0.
-   - Retorne APENAS o JSON válido, sem explicações, sem markdown, sem ```json.
+8. Retorne APENAS o JSON válido, sem explicações, sem markdown, sem ```json.
+
+{contexto_anterior}
 """
 
 # Retry config
@@ -101,18 +83,49 @@ def _parse_json_response(text: str) -> dict:
     return json.loads(cleaned)
 
 
-def extract_page(pdf_bytes: bytes, page_label: str = "") -> dict:
+def build_context_summary(extraction: dict) -> str:
+    """Build a context string from a previous page extraction.
+
+    Args:
+        extraction: Dict returned by extract_page for the previous page.
+
+    Returns:
+        A formatted context string, or "" if the extraction has no rows.
+    """
+    rows = extraction.get("rows", [])
+    if not rows:
+        return ""
+
+    first = rows[0]
+    last = rows[-1]
+    return (
+        "CONTEXTO DA PÁGINA ANTERIOR (use para continuidade):\n"
+        f"- Tipo: {extraction.get('type', '?')}\n"
+        f"- Primeira linha: {first.get('Conta', '?')} ({first.get('Mascara_Contabil', '?')})\n"
+        f"- Última linha: {last.get('Conta', '?')} ({last.get('Mascara_Contabil', '?')})"
+    )
+
+
+def extract_page(
+    pdf_bytes: bytes,
+    page_label: str = "",
+    contexto_anterior: str = "",
+) -> dict:
     """Send a single-page PDF to Gemini and return parsed JSON.
 
     Args:
         pdf_bytes: Raw bytes of a single-page PDF.
         page_label: Human-readable label for logging (e.g. "PDF1-Page3").
+        contexto_anterior: Optional context from the previous page extraction,
+            built via build_context_summary(). Injected into the prompt.
 
     Returns:
-        Parsed dict with keys: type, ano_atual, ano_anterior, rows.
+        Parsed dict with keys: type, periodo, ano_atual, ano_anterior, rows.
     """
     client = _get_client()
     model = os.environ.get("GEMINI_MODEL", "gemini-2.0-flash")
+
+    prompt = EXTRACTION_PROMPT.format(contexto_anterior=contexto_anterior)
 
     pdf_part = types.Part.from_bytes(data=pdf_bytes, mime_type="application/pdf")
 
@@ -121,7 +134,7 @@ def extract_page(pdf_bytes: bytes, page_label: str = "") -> dict:
         try:
             response = client.models.generate_content(
                 model=model,
-                contents=[pdf_part, EXTRACTION_PROMPT],
+                contents=[pdf_part, prompt],
             )
             result = _parse_json_response(response.text)
             logger.info(

--- a/app/validators.py
+++ b/app/validators.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 VALID_TYPES = {"BP", "DRE"}
 
-REQUIRED_ROW_FIELDS = ("Conta", "Mascara_Contabil", "Ano_Anterior", "Ano_Atual", "Macro")
+REQUIRED_ROW_FIELDS = ("Conta", "Mascara_Contabil", "Ano_Anterior", "Ano_Atual")
 
 
 def validar_extracao(extraction: dict, page_label: str) -> tuple[bool, list[str]]:


### PR DESCRIPTION
…xt support)

- Rewrite EXTRACTION_PROMPT: remove Macro field, add D/C debit/credit sign rules for Ativo/Passivo/Receita/Despesa, simplify format
- Add build_context_summary() to produce context from previous page extraction (type, first/last row) for multi-page continuity
- Add contexto_anterior parameter to extract_page() — injected into the prompt via {contexto_anterior} placeholder
- Update main.py to pass page context sequentially through the loop
- Remove Macro from validator required fields (Gemini no longer returns it; consolidator defaults to False)

https://claude.ai/code/session_018nQ1JjyPVtRLHx7m4xANbz